### PR TITLE
chore: configure Dependabot dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,43 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:30"
+      timezone: "Europe/Paris"
+    open-pull-requests-limit: 10
+    assignees:
+      - "glandais"
+    commit-message:
+      prefix: "deps(npm)"
+      include: "scope"
+    labels:
+      - "dependencies"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "10:00"
+      timezone: "Europe/Paris"
+    open-pull-requests-limit: 5
+    assignees:
+      - "glandais"
+    commit-message:
+      prefix: "deps(github-actions)"
+      include: "scope"
+    labels:
+      - "dependencies"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary

Adds a standard Dependabot configuration covering the following ecosystems:

- **npm** (`/`): weekly on Monday at 09:30, up to 10 PRs, minor+patch grouped
- **github-actions** (`/`): weekly on Monday at 10:00, up to 5 PRs, minor+patch grouped

All updates are assigned to `glandais`, use scoped commit prefixes, and are labelled `dependencies`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)